### PR TITLE
UI improvements

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,11 +13,28 @@ export default function Home() {
   };
 
   const handleChange = (row: number, col: number, value: string) => {
-    const updated = board.map((r) => [...r]);
-    const num = parseInt(value);
-    updated[row][col] = isNaN(num) ? 0 : num;
-    setBoard(updated);
+    if (value === "") {
+      const updated = board.map((r) => [...r]);
+      updated[row][col] = 0;
+      setBoard(updated);
+      return;
+    }
+
+    if (/^[1-9]$/.test(value)) {
+      const updated = board.map((r) => [...r]);
+      updated[row][col] = parseInt(value, 10);
+      setBoard(updated);
+    }
   };
+
+  const getCellStyle = (row: number, col: number) => ({
+    width: "40px",
+    height: "40px",
+    textAlign: "center" as const,
+    border: "1px solid #000",
+    borderRightWidth: col === 2 || col === 5 ? "3px" : "1px",
+    borderBottomWidth: row === 2 || row === 5 ? "3px" : "1px",
+  });
 
   return (
     <div style={{ padding: "2rem" }}>
@@ -26,19 +43,19 @@ export default function Home() {
         style={{
           display: "grid",
           gridTemplateColumns: "repeat(9, 40px)",
-          gap: "4px",
+          gap: 0,
         }}
       >
         {board.map((row, i) =>
           row.map((val, j) => (
             <input
               key={`${i}-${j}`}
-              type="number"
+              type="text"
+              inputMode="numeric"
+              maxLength={1}
               value={val === 0 ? "" : val}
               onChange={(e) => handleChange(i, j, e.target.value)}
-              style={{ width: "40px", height: "40px", textAlign: "center" }}
-              min="1"
-              max="9"
+              style={getCellStyle(i, j)}
             />
           ))
         )}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -32,8 +32,10 @@ export default function Home() {
     height: "40px",
     textAlign: "center" as const,
     border: "1px solid #000",
-    borderRightWidth: col === 2 || col === 5 ? "3px" : "1px",
-    borderBottomWidth: row === 2 || row === 5 ? "3px" : "1px",
+    borderLeftWidth: col === 3 || col === 6 || col === 0 ? "3px" : "1px",
+    borderTopWidth: row === 3 || row === 6 || row === 0 ? "3px" : "1px",
+    borderRightWidth: col === 8 ? "3px" : "1px",
+    borderBottomWidth: row === 8 ? "3px" : "1px",
   });
 
   return (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,9 +5,12 @@ export default function Home() {
   const [board, setBoard] = useState<number[][]>(
     Array.from({ length: 9 }, () => Array(9).fill(0))
   );
+  const [initialBoard, setInitialBoard] = useState<boolean[][]>(
+    Array.from({ length: 9 }, () => Array(9).fill(false))
+  );
 
   const handleTest = () => {
-    setBoard([
+    const test = [
       [0, 2, 0, 0, 0, 3, 0, 0, 0],
       [8, 9, 0, 0, 0, 1, 0, 0, 0],
       [0, 0, 3, 0, 0, 8, 6, 1, 0],
@@ -17,7 +20,9 @@ export default function Home() {
       [0, 0, 7, 0, 0, 0, 0, 0, 0],
       [0, 0, 5, 0, 0, 0, 2, 0, 9],
       [0, 0, 9, 3, 0, 0, 0, 0, 0],
-    ]);
+    ];
+    setBoard(test);
+    setInitialBoard(test.map((row) => row.map((v) => v !== 0)));
   };
 
   const handleSolve = () => {
@@ -41,10 +46,13 @@ export default function Home() {
     }
   };
 
-  const getCellStyle = (row: number, col: number) => ({
+  const getCellStyle = (row: number, col: number): React.CSSProperties => ({
     width: "40px",
     height: "40px",
     textAlign: "center" as const,
+    fontWeight: initialBoard[row][col] ? "bold" : "normal",
+    fontSize: initialBoard[row][col] ? "20px" : "16px",
+    color: initialBoard[row][col] ? "#555" : "#000",
     border: "1px solid #000",
     borderLeftWidth: col === 3 || col === 6 || col === 0 ? "3px" : "1px",
     borderTopWidth: row === 3 || row === 6 || row === 0 ? "3px" : "1px",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,6 +6,20 @@ export default function Home() {
     Array.from({ length: 9 }, () => Array(9).fill(0))
   );
 
+  const handleTest = () => {
+    setBoard([
+      [0, 2, 0, 0, 0, 3, 0, 0, 0],
+      [8, 9, 0, 0, 0, 1, 0, 0, 0],
+      [0, 0, 3, 0, 0, 8, 6, 1, 0],
+      [0, 0, 0, 0, 5, 9, 3, 0, 0],
+      [0, 5, 6, 1, 0, 2, 7, 0, 0],
+      [0, 0, 0, 6, 0, 0, 0, 8, 0],
+      [0, 0, 7, 0, 0, 0, 0, 0, 0],
+      [0, 0, 5, 0, 0, 0, 2, 0, 9],
+      [0, 0, 9, 3, 0, 0, 0, 0, 0],
+    ]);
+  };
+
   const handleSolve = () => {
     const copy = board.map((row) => [...row]);
     solveSudoku(copy);
@@ -22,6 +36,9 @@ export default function Home() {
   return (
     <div style={{ padding: "2rem" }}>
       <h1>Sudoku-lösare</h1>
+      <button onClick={handleTest} style={{ marginBottom: "1rem" }}>
+        TEST
+      </button>
       <div
         style={{
           display: "grid",


### PR DESCRIPTION
## Summary
- enforce digits 1-9 in the sudoku board inputs
- show borders to highlight 3x3 groups

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68814be8b8e0832bb1ee916a654e9902