### PR TITLE
Add TEST button to load preset puzzle

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,6 +6,20 @@ export default function Home() {
     Array.from({ length: 9 }, () => Array(9).fill(0))
   );
 
+  const handleTest = () => {
+    setBoard([
+      [0, 2, 0, 0, 0, 3, 0, 0, 0],
+      [8, 9, 0, 0, 0, 1, 0, 0, 0],
+      [0, 0, 3, 0, 0, 8, 6, 1, 0],
+      [0, 0, 0, 0, 5, 9, 3, 0, 0],
+      [0, 5, 6, 1, 0, 2, 7, 0, 0],
+      [0, 0, 0, 6, 0, 0, 0, 8, 0],
+      [0, 0, 7, 0, 0, 0, 0, 0, 0],
+      [0, 0, 5, 0, 0, 0, 2, 0, 9],
+      [0, 0, 9, 3, 0, 0, 0, 0, 0],
+    ]);
+  };
+
   const handleSolve = () => {
     const copy = board.map((row) => [...row]);
     solveSudoku(copy);
@@ -22,6 +36,9 @@ export default function Home() {
   return (
     <div style={{ padding: "2rem" }}>
       <h1>Sudoku-lösare</h1>
+      <button onClick={handleTest} style={{ marginBottom: "1rem" }}>
+        TEST
+      </button>
       <div
         style={{
           display: "grid",


### PR DESCRIPTION
## Summary
- add a `TEST` button that fills the board with a predefined Sudoku

## Testing
- `npm run build`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_b_688153895b34832b9f1bb8b77368a3cc