### PR TITLE
Highlight given sudoku numbers

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,9 +5,12 @@ export default function Home() {
   const [board, setBoard] = useState<number[][]>(
     Array.from({ length: 9 }, () => Array(9).fill(0))
   );
+  const [initialBoard, setInitialBoard] = useState<boolean[][]>(
+    Array.from({ length: 9 }, () => Array(9).fill(false))
+  );
 
   const handleTest = () => {
-    setBoard([
+    const test = [
       [0, 2, 0, 0, 0, 3, 0, 0, 0],
       [8, 9, 0, 0, 0, 1, 0, 0, 0],
       [0, 0, 3, 0, 0, 8, 6, 1, 0],
@@ -17,7 +20,9 @@ export default function Home() {
       [0, 0, 7, 0, 0, 0, 0, 0, 0],
       [0, 0, 5, 0, 0, 0, 2, 0, 9],
       [0, 0, 9, 3, 0, 0, 0, 0, 0],
-    ]);
+    ];
+    setBoard(test);
+    setInitialBoard(test.map((row) => row.map((v) => v !== 0)));
   };
 
   const handleSolve = () => {
@@ -41,10 +46,13 @@ export default function Home() {
     }
   };
 
-  const getCellStyle = (row: number, col: number) => ({
+  const getCellStyle = (row: number, col: number): React.CSSProperties => ({
     width: "40px",
     height: "40px",
     textAlign: "center" as const,
+    fontWeight: initialBoard[row][col] ? "bold" : "normal",
+    fontSize: initialBoard[row][col] ? "20px" : "16px",
+    color: initialBoard[row][col] ? "#555" : "#000",
     border: "1px solid #000",
     borderLeftWidth: col === 3 || col === 6 || col === 0 ? "3px" : "1px",
     borderTopWidth: row === 3 || row === 6 || row === 0 ? "3px" : "1px",


### PR DESCRIPTION
## Summary
- mark which cells were filled before solving
- keep `initialBoard` static while editing cells
- use bold font for the given numbers
- enlarge given numbers and use a subtle gray color

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68815ec4882c832b815b00690d6a4f0d